### PR TITLE
fix error when passing empty array to previewCmds

### DIFF
--- a/denops/@ddu-kinds/file.ts
+++ b/denops/@ddu-kinds/file.ts
@@ -444,7 +444,7 @@ export class Kind extends BaseKind<Params> {
 
     const param = ensureObject(args.actionParams) as PreviewOption;
 
-    if (action.path && param.previewCmds) {
+    if (action.path && param.previewCmds?.length) {
       const previewHeight = args.previewContext.height;
       let startLine = 0;
       let lineNr = 0;


### PR DESCRIPTION
An error occurs when an empty array is passed to `previewCmds` as shown below. I feel that passing an empty array is a problem, but it is better to try to ignore it.

```vim
call ddu#ui#ff#do_action('preview', {'previewCmds' : [], })
```

<details>
<summary>error message</summary>

```
Error detected while processing function ddu#ui#ff#do_action[13]..ddu#ui_action[1]..ddu#_request[22]..denops#request[1]..denops#server#request[6]..<SNR>30_request:
line    1:
Error invoking 'invoke' on channel 4:
Error: Failed to call 'uiAction' with ["default","preview",{"previewCmds":[]}]: Error: Failed to call 'call' with ["termopen",[]]: Error: Failed to call 'nvim_call_function' with ["termopen",[[]]]: [0,"Vim:E474: Invalid argument"]
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async Service.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:92:12)
    at async Session.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:141:14)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async DenopsImpl.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops/impl.ts:28:12)
    at async PreviewUi.previewTerminal (file:///home/erw7/src/github.com/Shougo/ddu-ui-ff/denops/@ddu-ui-ff/preview.ts:152:7)
    at async PreviewUi.preview (file:///home/erw7/src/github.com/Shougo/ddu-ui-ff/denops/@ddu-ui-ff/preview.ts:98:14)
    at async Ddu.uiAction (file:///home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu.vim/denops/ddu/ddu.ts:394:19)
    at async Session.uiAction (file:///home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu.vim/denops/ddu/app.ts:206:7)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async Service.dispatch (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:107:14)
    at async Session.invoke (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/host/nvim.ts:48:16)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
```
</details>