### PR TITLE
newFile action end with /, create directory

### DIFF
--- a/denops/@ddu-kinds/file.ts
+++ b/denops/@ddu-kinds/file.ts
@@ -252,7 +252,11 @@ export class Kind extends BaseKind<Params> {
         return ActionFlags.Persist;
       }
 
-      await Deno.writeTextFile(newFile, "");
+      if (newFile.slice(-1) == "/"){
+        await Deno.mkdir(newFile);
+      } else {
+        await Deno.writeTextFile(newFile, "");
+      }
 
       return ActionFlags.RefreshItems;
     },

--- a/doc/ddu-kind-file.txt
+++ b/doc/ddu-kind-file.txt
@@ -84,6 +84,7 @@ newDirectory
 						*ddu-kind-file-action-newFile*
 newFile
 		Make new file.
+		If the input ends with "/", it means new directory.
 
 						*ddu-kind-file-action-open*
 open


### PR DESCRIPTION
If newFile action input ends with "/", create new directory instead of new file. This behavior is the same as new_file of defx.nvim

try to create new file which ends with "/", error is occurred.