### PR TITLE
Fix bufNr nullish check

### DIFF
--- a/denops/@ddu-kinds/file.ts
+++ b/denops/@ddu-kinds/file.ts
@@ -675,7 +675,7 @@ export class Kind extends BaseKind<Params> {
 
     return {
       kind: "buffer",
-      path: action.bufNr === undefined ? action.path : undefined,
+      path: action.bufNr ? undefined : action.path,
       expr: action.bufNr,
       lineNr: action.lineNr,
     };


### PR DESCRIPTION
Some sources return ActionData like `{bufNr: undefined}`.
However, it is converted to `{bufNr: null}` when passed through the denops layer.
We should consider the possibility of a null value instead of undefined.